### PR TITLE
[WIP] README.mbでテーブルの概要を記述

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,50 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false, unique: true|
+|email|string|null: false, unique: true|
+|pass|string|null: false|
+
+### Association
+- has_many :messages
+- has_many :groups_users
+- has_many :groups, through:groups_users
+
+## groupsテーブル
+
+|Column|Type|Options|
+|name|string|null: false|
+
+### Association
+- has_many :messages
+- has_many :groups_users
+- has_many :users, through:groups_users
+
+## messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|image|string||
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :user
+- belongs_to :group
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null: false|
+|body|text||
 |image|string||
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Things you may want to cover:
 
 * ...
 
+
 ## usersテーブル
 
 |Column|Type|Options|
@@ -39,6 +40,7 @@ Things you may want to cover:
 ## groupsテーブル
 
 |Column|Type|Options|
+|------|----|-------|
 |name|string|null: false|
 
 ### Association


### PR DESCRIPTION
#What
README.mbによるテーブルの概要を書き出し。

#Why
chat-spaceデータベースのテーブルを書き出し、記入漏れがないか明確にするため。
